### PR TITLE
fix random circles in sand

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,7 @@ def run_theta_rho_file(file_path):
     global stop_requested
     stop_requested = False
 
-    coordinates = parse_theta_rho_file(file_path, True)
+    coordinates = parse_theta_rho_file(file_path, apply_transformations = False)
     if len(coordinates) < 2:
         print("Not enough coordinates for interpolation.")
         return


### PR DESCRIPTION
With coordinates = parse_theta_rho_file(file_path, apply_transformations = True) the ball makes circles in the sand for some of the figures. It seems to be due to the jump due to the transformation over the 2xpi value
