### PR TITLE
Support Secure Websockets

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -166,7 +166,7 @@ function connectWebSocket() {
         ws.close();
     }
 
-    ws = new WebSocket(`ws://${window.location.host}/ws/status`);
+    ws = new WebSocket(`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws/status`);
     
     ws.onopen = function() {
         console.log("WebSocket connection established");


### PR DESCRIPTION
This PR adds support for Secure WebSockets from the Client browser.

I use an internal reverse proxy and this hard coded setting prevents this from working.