### PR TITLE
fix(mqtt): apply clear pattern when selecting a single pattern

### DIFF
--- a/modules/mqtt/handler.py
+++ b/modules/mqtt/handler.py
@@ -678,7 +678,10 @@ class MQTTHandler(BaseMQTTHandler):
                 if pattern_name in self.patterns:
                     # Schedule the coroutine to run in the main event loop
                     asyncio.run_coroutine_threadsafe(
-                        self.callback_registry['run_pattern'](file_path=f"{THETA_RHO_DIR}/{pattern_name}"),
+                        self.callback_registry['run_pattern'](
+                            file_path=f"{THETA_RHO_DIR}/{pattern_name}",
+                            clear_pattern=self.state.clear_pattern,
+                        ),
                         self.main_loop
                     ).add_done_callback(
                         lambda _: self._publish_pattern_state(None)  # Clear pattern after execution


### PR DESCRIPTION
This fixes an inconsistency in MQTT behavior between single pattern runs and playlist runs.

Before this change, selecting a pattern from Home Assistant started that pattern directly, even if a clear pattern was configured. The clear pattern setting was only respected when starting a playlist.

Now the single-pattern MQTT path passes the configured clear_pattern into run_pattern, so both flows behave the same way. If clear_pattern is set to none, behavior stays unchanged.