### PR TITLE
fix(backend): repeat playlists when run_mode is loop

### DIFF
--- a/modules/core/pattern_manager.py
+++ b/modules/core/pattern_manager.py
@@ -1685,8 +1685,8 @@ async def run_theta_rho_files(file_paths, pause_time=0, clear_pattern=None, run_
                 state.skip_requested = False
                 idx += 1
 
-            if run_mode == "indefinite":
-                logger.info("Playlist completed. Restarting as per 'indefinite' run mode")
+            if run_mode in ("indefinite", "loop"):
+                logger.info(f"Playlist completed. Restarting as per '{run_mode}' run mode")
                 if pause_time > 0:
                     # Clear current_playing_file to report "idle" state to MQTT/HA during pause
                     state.current_playing_file = None

--- a/tests/unit/test_pattern_manager.py
+++ b/tests/unit/test_pattern_manager.py
@@ -7,9 +7,8 @@ Tests the core pattern file operations:
 - Error handling for invalid files
 - Listing pattern files
 """
-import os
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch
 
 
 class TestParseTheTaRhoFile:
@@ -350,3 +349,56 @@ class TestIsClearPattern:
         assert is_clear_pattern("./patterns/circle.thr") is False
         assert is_clear_pattern("./patterns/spiral.thr") is False
         assert is_clear_pattern("./patterns/custom/my_pattern.thr") is False
+
+
+class TestPlaylistRunModes:
+    """Tests for run_theta_rho_files repeat behavior.
+
+    The manual "Run Playlist" dialog sends run_mode="indefinite", while
+    auto-play and MQTT send run_mode="loop". Both must repeat the playlist;
+    "single" must stop after one pass.
+    """
+
+    PLAYLIST = ["a.thr", "b.thr"]
+
+    async def _run_playlist(self, mock_state, run_mode, stop_after):
+        """Run a playlist with a stubbed pattern executor.
+
+        Requests a stop once the executor has run stop_after patterns (so
+        repeat modes can't spin forever), then returns the executed files.
+        """
+        executed = []
+
+        async def fake_run_pattern(file_path, **kwargs):
+            executed.append(file_path)
+            if len(executed) >= stop_after:
+                mock_state.stop_requested = True
+
+        with patch("modules.core.pattern_manager.state", mock_state), \
+             patch("modules.core.pattern_manager.run_theta_rho_file",
+                   AsyncMock(side_effect=fake_run_pattern)), \
+             patch("modules.core.pattern_manager.broadcast_progress", AsyncMock()), \
+             patch("modules.core.pattern_manager.start_idle_led_timeout", AsyncMock()):
+            from modules.core.pattern_manager import run_theta_rho_files
+
+            await run_theta_rho_files(list(self.PLAYLIST), run_mode=run_mode)
+
+        return executed
+
+    async def test_run_mode_single_stops_after_one_pass(self, mock_state):
+        """A "single" playlist runs each pattern once and completes."""
+        executed = await self._run_playlist(mock_state, "single", stop_after=10)
+
+        assert executed == ["a.thr", "b.thr"]
+
+    async def test_run_mode_indefinite_restarts_playlist(self, mock_state):
+        """An "indefinite" playlist restarts after the last pattern."""
+        executed = await self._run_playlist(mock_state, "indefinite", stop_after=3)
+
+        assert executed == ["a.thr", "b.thr", "a.thr"]
+
+    async def test_run_mode_loop_restarts_playlist(self, mock_state):
+        """A "loop" playlist (auto-play/MQTT) restarts after the last pattern."""
+        executed = await self._run_playlist(mock_state, "loop", stop_after=3)
+
+        assert executed == ["a.thr", "b.thr", "a.thr"]


### PR DESCRIPTION
## What

One-line fix in `run_theta_rho_files`: accept `"loop"` in addition to `"indefinite"` as a repeat mode, plus unit tests covering all three run modes.

## Why

The codebase uses two different words for "repeat forever":

- The manual **Run Playlist** dialog sends `run_mode="indefinite"`.
- **Auto-play** and **MQTT** send `run_mode="loop"` (the default for `auto_play_run_mode`).

The restart check at the end of the playlist runner only tested `run_mode == "indefinite"`, so auto-play playlists ran a single pass and stopped. Manual runs looped fine, which is probably why this was never caught — the one existing test touching this area also uses `"indefinite"`.

Log evidence from an overnight run on a Raspberry Pi table (auto-play, `mode=loop`):

```
Jun 25 23:41:52  Starting playlist 'Ambient' with mode=loop, shuffle=True
Jun 26 11:28:01  Playlist completed        <- hit the break branch, never restarted
```

## How

`modules/core/pattern_manager.py`: `if run_mode == "indefinite":` becomes `if run_mode in ("indefinite", "loop"):`, and the restart log message is made mode-agnostic. This also fixes MQTT-triggered looping, and leaves `"single"` and manual `"indefinite"` behavior untouched.

## Testing

- New unit tests in `tests/unit/test_pattern_manager.py`: `"single"` completes after one pass, `"indefinite"` restarts, `"loop"` restarts. The `"loop"` test fails without this fix.
- Verified live on a Dune Weaver (Pi 4 + FluidNC): with this change, auto-play re-enters the playlist cleanly after the last pattern instead of going idle.
- `pytest tests/unit/ -v`: 107 passed. `ruff check` clean on touched files (also removed two pre-existing unused imports in the touched test file).

Fixes #136
