### PR TITLE
fix(backend): re-shuffle playlists on each repeat cycle

### DIFF
--- a/modules/core/pattern_manager.py
+++ b/modules/core/pattern_manager.py
@@ -1539,11 +1539,6 @@ async def run_theta_rho_files(file_paths, pause_time=0, clear_pattern=None, run_
     if not progress_update_task:
         progress_update_task = asyncio.create_task(broadcast_progress())
 
-    # Shuffle main patterns if requested (before starting)
-    if shuffle:
-        random.shuffle(file_paths)
-        logger.info("Playlist shuffled")
-
     # Store patterns in state only if not already set by caller.
     # The caller (playlist_manager.run_playlist) sets this before creating the task.
     if state.current_playlist is None:
@@ -1551,6 +1546,13 @@ async def run_theta_rho_files(file_paths, pause_time=0, clear_pattern=None, run_
 
     try:
         while True:
+            # Shuffle main patterns if requested. Re-shuffle at the start of
+            # every cycle so repeat modes play a fresh order each pass instead
+            # of replaying the first random order forever.
+            if shuffle and state.current_playlist:
+                random.shuffle(state.current_playlist)
+                logger.info("Playlist shuffled")
+
             # Load metadata cache once per playlist iteration (for adaptive clear patterns)
             cache_data = None
             if clear_pattern and clear_pattern in ['adaptive', 'clear_from_in', 'clear_from_out']:

--- a/tests/unit/test_pattern_manager.py
+++ b/tests/unit/test_pattern_manager.py
@@ -7,9 +7,8 @@ Tests the core pattern file operations:
 - Error handling for invalid files
 - Listing pattern files
 """
-import os
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch
 
 
 class TestParseTheTaRhoFile:
@@ -314,6 +313,61 @@ class TestGetStatus:
         assert status["playlist"]["total_files"] == 3
         assert status["playlist"]["mode"] == "indefinite"
         assert status["playlist"]["name"] == "test_playlist"
+
+
+class TestPlaylistShuffle:
+    """Tests for playlist shuffle behavior in run_theta_rho_files."""
+
+    async def test_shuffle_reshuffles_on_each_repeat_cycle(self, mock_state):
+        """With shuffle enabled, a repeating playlist must re-shuffle every
+        cycle instead of replaying the first random order forever."""
+        playlist = ["a.thr", "b.thr"]
+        executed = []
+        shuffle_calls = []
+
+        async def fake_run_pattern(file_path, **kwargs):
+            executed.append(file_path)
+            if len(executed) >= 3:
+                mock_state.stop_requested = True
+
+        with patch("modules.core.pattern_manager.state", mock_state), \
+             patch("modules.core.pattern_manager.run_theta_rho_file",
+                   AsyncMock(side_effect=fake_run_pattern)), \
+             patch("modules.core.pattern_manager.broadcast_progress", AsyncMock()), \
+             patch("modules.core.pattern_manager.start_idle_led_timeout", AsyncMock()), \
+             patch("modules.core.pattern_manager.random.shuffle",
+                   side_effect=lambda seq: shuffle_calls.append(list(seq))):
+            from modules.core.pattern_manager import run_theta_rho_files
+
+            await run_theta_rho_files(playlist, run_mode="indefinite", shuffle=True)
+
+        # The playlist restarted once (3 patterns executed from a 2-pattern
+        # playlist), so it must have been shuffled twice: once per cycle.
+        assert len(executed) == 3
+        assert len(shuffle_calls) == 2
+
+    async def test_no_shuffle_preserves_order(self, mock_state):
+        """Without shuffle, the playlist order is never touched."""
+        playlist = ["a.thr", "b.thr"]
+        executed = []
+        shuffle_calls = []
+
+        async def fake_run_pattern(file_path, **kwargs):
+            executed.append(file_path)
+
+        with patch("modules.core.pattern_manager.state", mock_state), \
+             patch("modules.core.pattern_manager.run_theta_rho_file",
+                   AsyncMock(side_effect=fake_run_pattern)), \
+             patch("modules.core.pattern_manager.broadcast_progress", AsyncMock()), \
+             patch("modules.core.pattern_manager.start_idle_led_timeout", AsyncMock()), \
+             patch("modules.core.pattern_manager.random.shuffle",
+                   side_effect=lambda seq: shuffle_calls.append(list(seq))):
+            from modules.core.pattern_manager import run_theta_rho_files
+
+            await run_theta_rho_files(playlist, run_mode="single", shuffle=False)
+
+        assert executed == ["a.thr", "b.thr"]
+        assert shuffle_calls == []
 
 
 class TestIsClearPattern:


### PR DESCRIPTION
## What

Move the playlist shuffle from before the playback loop to the top of each cycle in `run_theta_rho_files`, plus unit tests.

## Why

Shuffle currently runs once, before the loop starts. For a repeating playlist that means one random order is drawn at start time and then replayed identically forever — on a table that runs auto-play for days, shuffle effectively stops working after the first cycle.

## How

In `modules/core/pattern_manager.py`, the pre-loop `random.shuffle(file_paths)` block moves inside `while True:`, shuffling `state.current_playlist` (the list playback actually reads) at the start of every cycle:

```python
while True:
    if shuffle and state.current_playlist:
        random.shuffle(state.current_playlist)
        logger.info("Playlist shuffled")
```

Single-pass playlists still shuffle exactly once, so nothing changes for `run_mode="single"`. The shuffle stays in-place, so mid-run reordering semantics are unchanged.

## Testing

- New unit tests: a repeating shuffled playlist re-shuffles once per cycle (fails without this fix); an unshuffled playlist preserves order and never calls shuffle.
- Verified live on a Dune Weaver (Pi 4 + FluidNC) running multi-day auto-play: each cycle logs a fresh "Playlist shuffled" and plays a different order.
- `pytest tests/unit/ -v`: 106 passed. `ruff check` clean on touched files (also removed two pre-existing unused imports in the touched test file).

Note: merges cleanly with #138 in either order (verified locally with both applied — 27/27 pattern_manager tests pass on the combined tree).

Fixes #137
